### PR TITLE
ci: add QEMU + multi-arch build (amd64+arm64)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -49,6 +52,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
## Summary

- Add `docker/setup-qemu-action@v3` step before `setup-buildx-action` so the builder can emulate ARM
- Add `platforms: linux/amd64,linux/arm64` to the `build-push-action` step

Prod VM is now ARM (Oracle), so the GHCR image needs to ship both architectures. Everything else — triggers, env, permissions, metadata tags, GHA cache — is untouched. Diff is exactly 2 additions in `deploy.yml`.

## Test plan

- [ ] Merge to `develop` and verify the workflow run produces a multi-arch manifest (`docker buildx imagetools inspect ghcr.io/vhrita/definitive-portfolio:sha-<sha>` shows both `linux/amd64` and `linux/arm64`)
- [ ] Confirm the ARM VM can pull without the `--platform` flag workaround

---
Built by VHXCO Agentic Software House

Co-Authored-By: VHXCO Builder <ops@vhxco.io>